### PR TITLE
Bugfix 31782 start learning sequence is no primary button

### DIFF
--- a/Modules/LearningSequence/classes/Player/class.ilObjLearningSequenceLearnerGUI.php
+++ b/Modules/LearningSequence/classes/Player/class.ilObjLearningSequenceLearnerGUI.php
@@ -134,9 +134,9 @@ class ilObjLearningSequenceLearnerGUI
         } else {
             if (!$completed) {
                 $res_button = ilLinkButton::getInstance();
+                $res_button->setPrimary(true);
                 $res_button->setCaption("lso_player_resume");
                 if ($this->first_access === -1) {
-                    $res_button->setPrimary(true);
                     $res_button->setCaption("lso_player_start");
                 }
                 $res_button->setUrl($this->ctrl->getLinkTarget($this, self::CMD_VIEW));

--- a/Modules/LearningSequence/classes/Player/class.ilObjLearningSequenceLearnerGUI.php
+++ b/Modules/LearningSequence/classes/Player/class.ilObjLearningSequenceLearnerGUI.php
@@ -125,48 +125,48 @@ class ilObjLearningSequenceLearnerGUI
         if (!$is_member) {
             $may_subscribe = $this->userMayJoin();
             if ($may_subscribe) {
-                $this->toolbar->addButton(
-                    $this->lng->txt("lso_player_start"),
-                    $this->ctrl->getLinkTarget($this, self::CMD_START)
-                );
+                $sub_button = ilLinkButton::getInstance();
+                $sub_button->setPrimary(true);
+                $sub_button->setCaption("lso_player_start");
+                $sub_button->setUrl($this->ctrl->getLinkTarget($this,self::CMD_START));
+                $this->toolbar->addButtonInstance($sub_button);
             }
         } else {
             if (!$completed) {
-                $label = "lso_player_resume";
+                $res_button = ilLinkButton::getInstance();
+                $res_button->setCaption("lso_player_resume");
                 if ($this->first_access === -1) {
-                    $label = "lso_player_start";
+                    $res_button->setPrimary(true);
+                    $res_button->setCaption("lso_player_start");
                 }
-
-                $this->toolbar->addButton(
-                    $this->lng->txt($label),
-                    $this->ctrl->getLinkTarget($this, self::CMD_VIEW)
-                );
+                $res_button->setUrl($this->ctrl->getLinkTarget($this, self::CMD_VIEW));
+                $this->toolbar->addButtonInstance($res_button);
             } else {
-                $this->toolbar->addButton(
-                    $this->lng->txt("lso_player_review"),
-                    $this->ctrl->getLinkTarget($this, self::CMD_VIEW)
-                );
+                $review_button = ilLinkButton::getInstance();
+                $review_button->setCaption("lso_player_review");
+                $review_button->setUrl($this->ctrl->getLinkTarget($this, self::CMD_VIEW));
+                $this->toolbar->addButtonInstance($review_button);
 
                 if ($cmd === self::CMD_STANDARD) {
-                    $this->toolbar->addButton(
-                        $this->lng->txt("lso_player_extro"),
-                        $this->ctrl->getLinkTarget($this, self::CMD_EXTRO)
-                    );
+                    $button = ilLinkButton::getInstance();
+                    $button->setCaption("lso_player_extro");
+                    $button->setUrl($this->ctrl->getLinkTarget($this, self::CMD_EXTRO));
+                    $this->toolbar->addButtonInstance($button);
                 }
                 if ($cmd === self::CMD_EXTRO) {
-                    $this->toolbar->addButton(
-                        $this->lng->txt("lso_player_abstract"),
-                        $this->ctrl->getLinkTarget($this, self::CMD_STANDARD)
-                    );
+                    $button = ilLinkButton::getInstance();
+                    $button->setCaption("lso_player_abstract");
+                    $button->setUrl($this->ctrl->getLinkTarget($this, self::CMD_STANDARD));
+                    $this->toolbar->addButtonInstance($button);
                 }
             }
 
             $may_unsubscribe = $this->userMayUnparticipate();
             if ($may_unsubscribe) {
-                $this->toolbar->addButton(
-                    $this->lng->txt("unparticipate"),
-                    $this->ctrl->getLinkTarget($this, self::CMD_UNSUBSCRIBE)
-                );
+                $unsub_button = ilLinkButton::getInstance();
+                $unsub_button->setCaption("unparticipate");
+                $unsub_button->setUrl($this->ctrl->getLinkTarget($this, self::CMD_UNSUBSCRIBE));
+                $this->toolbar->addButtonInstance($unsub_button);
             }
         }
     }


### PR DESCRIPTION
#bugfix
Mantis issue: 0031782
Target: release_7
https://mantis.ilias.de/view.php?id=31782

To turn the "start learning sequence"-button into a primary button, I replaced the deprecated addButton()-method with the new addButtonInstance()-method. For the sake of clarity, I replaced the addButton()-method in the entire function and made "resume learning sequence" also a primary button. 