### PR TITLE
Bugfix 30706 Error commenting on a learning sequence

### DIFF
--- a/Modules/LearningSequence/classes/class.ilObjLearningSequenceGUI.php
+++ b/Modules/LearningSequence/classes/class.ilObjLearningSequenceGUI.php
@@ -67,6 +67,7 @@ class ilObjLearningSequenceGUI extends ilContainerGUI
     const CMD_PERFORM_PASTE = 'performPasteIntoMultipleObjects';
     const CMD_SHOW_TRASH = 'trash';
     const CMD_UNDELETE = 'undelete';
+    const CMD_REDRAW_HEADER = 'redrawHeaderAction';
 
     const TAB_VIEW_CONTENT = "view_content";
     const TAB_MANAGE = "manage";
@@ -344,6 +345,10 @@ class ilObjLearningSequenceGUI extends ilContainerGUI
                     case self::CMD_CANCEL_LINK:
                         $cmd = self::CMD_CONTENT;
                         $this->$cmd();
+                        break;
+
+                    case self::CMD_REDRAW_HEADER:
+                        $this->redrawHeaderActionObject();
                         break;
 
                     default:


### PR DESCRIPTION
#bugfix
Mantis issue: 0030706
Target: release_7
https://mantis.ilias.de/view.php?id=30706

Bug was reported for Ilias 6.9, but still occurs in Ilias 7, so I fixed it there.

