### PR TITLE
Bugfix 33747 Entries of a copied DS are not displayed

### DIFF
--- a/Modules/DataCollection/classes/TableView/class.ilDclTableViewFieldSetting.php
+++ b/Modules/DataCollection/classes/TableView/class.ilDclTableViewFieldSetting.php
@@ -503,6 +503,7 @@ class ilDclTableViewFieldSetting extends ActiveRecord
         $this->setInFilter($orig->isInFilter());
         $this->setVisibleCreate($orig->isVisibleCreate());
         $this->setVisibleEdit($orig->isVisibleEdit());
+        $this->setVisible($orig->isVisibleInList());
         $this->setLockedCreate($orig->isLockedCreate());
         $this->setLockedEdit($orig->isLockedEdit());
         $this->setRequiredCreate($orig->isRequiredCreate());


### PR DESCRIPTION
#bugfix
Mantis issue: 33747 and 32228
Target: release_7
https://mantis.ilias.de/view.php?id=33747
https://mantis.ilias.de/view.php?id=32228

Both tickets refer to the same bug.